### PR TITLE
chore(web): add AGENT_URL env var to web

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -15,3 +15,6 @@ CRON_SECRET=YOUR_CRON_SECRET_HERE
 
 # Used to validate preview requests
 PREVIEW_SECRET=YOUR_SECRET_HERE
+
+# ForTheChurch agent API
+AGENT_URL=http://localhost:3005

--- a/web/src/environment.d.ts
+++ b/web/src/environment.d.ts
@@ -4,7 +4,8 @@ declare global {
       PAYLOAD_SECRET: string
       DATABASE_URI: string
       NEXT_PUBLIC_SERVER_URL: string
-      VERCEL_PROJECT_PRODUCTION_URL: string
+      VERCEL_PROJECT_PRODUCTION_URL: string,
+      AGENT_URL: string
     }
   }
 }

--- a/web/src/payload.config.ts
+++ b/web/src/payload.config.ts
@@ -4,7 +4,6 @@ import path from 'path'
 import { buildConfig, PayloadRequest, WorkflowConfig } from 'payload'
 import sharp from 'sharp' // sharp-import
 import { fileURLToPath } from 'url'
-import axios from 'axios'
 
 import { defaultLexical } from '@/fields/defaultLexical'
 import { Categories } from './collections/Categories'
@@ -20,7 +19,7 @@ import { Header } from './Header/config'
 import { Logo } from './Logo/config'
 import { plugins } from './plugins'
 import { getServerSideURL } from './utilities/getURL'
-import { SinglePageConversion } from './payload-types'
+import agentApi from './utilities/agentApi'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
@@ -152,7 +151,7 @@ export default buildConfig({
           }
 
           // TODO: Don't hardcode
-          const response = await axios.post("http://localhost:3005/api/pages/convert-single-page",
+          const response = await agentApi.post("/pages/convert-single-page",
             {
               url,
               pageId: documentId
@@ -215,7 +214,7 @@ export default buildConfig({
           const endTime = Date.now() + timeoutMs;
           while (true) {
             // TODO: Don't hardcode
-            const response = await axios.get(`http://localhost:3005/api/pages/task/${agentTaskId}`);
+            const response = await agentApi.get("/pages/task/${agentTaskId}");
 
             const { task_status: agentTaskStatus } = response.data;
 

--- a/web/src/utilities/agentApi.ts
+++ b/web/src/utilities/agentApi.ts
@@ -1,0 +1,7 @@
+import axios from "axios";
+
+const agentApi = axios.create({
+    baseURL: `${process.env.AGENT_URL || 'http://localhost:3005'}/api`,
+});
+
+export default agentApi;


### PR DESCRIPTION
Added an `AGENT_URL` environment variable to the web payload application. Add this variable to /web/.env to set the base URL that the AI agent is listening on. Defaults to http://localhost:3005.