### PR TITLE
feat(web): add an image upload tool for the chat agent

### DIFF
--- a/web/src/app/api/chat/prompt.ts
+++ b/web/src/app/api/chat/prompt.ts
@@ -34,7 +34,8 @@ You are able to use the following tools:
 - \`addNavigationItem\`: Adds a navigation item to the top-level navigation. Do not ask the user what position to add it at. You can make a reasonable guess for them.
 - \`removeNavigationItem\`: Removes a navigation item from the top-level navigation.
 - \`searchSermonPosts\`: Searches for sermon posts.
-- \`getSermonPostContent\`: Gets the content of a sermon post. Returns the content in markdown foramt.
+- \`getSermonPostContent\`: Gets the content of a sermon post. Returns the content in markdown format.
+- \`uploadImageFromUrl\`: Uploads an image from a URL to the Media collection. Use the response's media ID in page updates or creates.
 
 If you make any changes to pages, forms, or events, it must abide by the following TypeScript type definitions:
 

--- a/web/src/app/api/chat/route.ts
+++ b/web/src/app/api/chat/route.ts
@@ -20,6 +20,7 @@ import {
   searchSermonPostsTool,
   updateEventTool,
   updatePageTool,
+  uploadImageFromUrlTool,
 } from './tools'
 import { systemPrompt } from './prompt'
 
@@ -54,6 +55,7 @@ export async function POST(req: Request) {
       updateEvent: updateEventTool,
       searchSermonPosts: searchSermonPostsTool,
       getSermonPostContent: getSermonPostContentTool,
+      uploadImageFromUrl: uploadImageFromUrlTool,
       // add backend tools here
     },
   })

--- a/web/src/app/api/chat/tools.ts
+++ b/web/src/app/api/chat/tools.ts
@@ -1,4 +1,6 @@
 import { tool } from 'ai'
+import path from 'path'
+import { URL } from 'url'
 import { getPayload, RichTextField, TabsField } from 'payload'
 import config from '@payload-config'
 import { z } from 'zod'
@@ -367,6 +369,71 @@ export const getSermonPostContentTool = tool({
       id: post.id,
       title: post.title,
       content: markdown,
+    }
+  },
+})
+
+function getFileExt(res: Response) {
+  const contentType = res.headers.get('content-type') || 'image/jpeg'
+  const ext = contentType.split('/')[1]
+  return ext
+}
+
+function getFilename(res: Response, imageUrl: string): string {
+  // Try Content-Disposition
+  const disposition = res.headers.get('content-disposition')
+  if (disposition) {
+    const match = disposition.match(/filename\*?=(?:UTF-8'')?"?([^"]+)"?/)
+    if (match?.[1]) return match[1]
+  }
+
+  // Try URL path
+  const ext = getFileExt(res) || '.jpg'
+  try {
+    const url = new URL(imageUrl)
+    const base = path.basename(url.pathname)
+    if (base && base.includes('.')) return base
+    if (base && ext) return `${base}.${ext}`
+  } catch { }
+
+  // Fallback to extension from content-type
+  return `downloaded.${ext}`
+}
+
+export const uploadImageFromUrlTool = tool({
+  description: 'Uploads an image from a URL to the Media collection',
+  inputSchema: z.object({
+    url: z.url().describe('The URL of the image to download'),
+    alt: z.string().optional().describe("The alt text"),
+  }),
+  execute: async ({ url, alt }: { url: string, alt?: string }) => {
+    const res = await fetch(url)
+    if (!res.ok) throw new Error(`Failed to fetch image: ${res.statusText}`)
+
+    const arrayBuffer = await res.arrayBuffer()
+    const buffer = Buffer.from(arrayBuffer)
+    const mimetype = res.headers.get('content-type') || 'image/jpeg'
+    const size = buffer.byteLength
+    const filename = getFilename(res, url)
+
+    const payload = await getPayload({ config })
+    const doc = await payload.create({
+      collection: 'media',
+      data: {
+        alt: alt || `Uploaded from ${url}`,
+      },
+      file: {
+        data: buffer,
+        mimetype,
+        name: filename,
+        size
+      },
+    })
+
+    return {
+      id: doc.id,
+      filename: doc.filename,
+      url: doc.url,
     }
   },
 })

--- a/web/src/components/AdminAssistant/index.tsx
+++ b/web/src/components/AdminAssistant/index.tsx
@@ -19,6 +19,7 @@ import {
   SearchSermonPostsToolUI,
   UpdateEventToolUI,
   UpdatePageToolUI,
+  UploadImageFromUrlToolUI,
 } from '@/components/AdminAssistant/tools'
 import { Thread } from '@/components/assistant-ui/thread'
 import { ThreadList } from '@/components/assistant-ui/thread-list'
@@ -58,6 +59,7 @@ const AdminAssistant: React.FC = () => {
           <PublishEventToolUI />
           <SearchSermonPostsToolUI />
           <GetSermonPostContentToolUI />
+          <UploadImageFromUrlToolUI />
           <TooltipProvider>
             <div className="grid lg:grid-cols-[200px_1fr] gap-6">
               <div className="border border-gray-200 rounded-lg">

--- a/web/src/components/AdminAssistant/tools.tsx
+++ b/web/src/components/AdminAssistant/tools.tsx
@@ -797,3 +797,43 @@ export const GetSermonPostContentToolUI = makeAssistantToolUI<
     )
   },
 })
+
+export const UploadImageFromUrlToolUI = makeAssistantToolUI<
+  { url: string },
+  | {
+      id: string
+      filename: string
+      url: string
+    }
+  | ErrorResult
+>({
+  toolName: 'uploadImageFromUrl',
+  render: ({ result, status }) => {
+    if (status.type === 'running') {
+      return (
+        <ToolWrapper>
+          <Loader2Icon className="animate-spin text-blue-600" /> Uploading image...
+        </ToolWrapper>
+      )
+    }
+    if (isErrorResult(result)) {
+      return (
+        <ToolWrapper>
+          <div className="flex flex-col gap-2">
+            <div className="flex flex-row gap-2 items-center">
+              <XIcon className="text-red-500" />{' '}
+              <div className="text-red-500">Failed to upload image</div>
+            </div>
+            <div className="text-gray-500">Error: {result?.error}</div>
+          </div>
+        </ToolWrapper>
+      )
+    }
+
+    return (
+      <ToolWrapper>
+        <CheckIcon className="text-green-600" /> Upload successful: <i>{result?.filename}</i>
+      </ToolWrapper>
+    )
+  },
+})


### PR DESCRIPTION
Adds an `uploadImageFromUrl` tool to the chat agent to allow adding images from URLs.